### PR TITLE
Remove files from dist/*.html loaded by html-loader #69

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -52,8 +52,9 @@ module.exports = {
     new CopyWebpackPlugin([
       { from: '../README.md' },
       { from: '**/plugin.json' },
-      { from: '**/*.html' },
-      { from: 'components/*' },
+      { from: 'panel/**/*.html' },
+      { from: 'datasource/**/*.html' },
+      { from: 'components/**/*.html' },
       { from: 'dashboards/*' },
       { from: 'img/*' },
     ]),


### PR DESCRIPTION
Closes #69 

Don't copy `*.html` files from `config/` because it's loaded by `html-loader`